### PR TITLE
Reset button and tests

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -34,6 +34,9 @@ $ k set sign <sign_id> for kiosk <kiosk_id>
 You can install the "things" version of the app on a NXP i.MX7D Starter Kit. The installation process is
 the same. Connect the device and use adb or Android Studio to install the application.
 
+The things version of the app is similar to the mobile version. You can change how the image is scaled by
+touching the "A" button or reset the kiosk by pressing the "C" button three times in a row. Oh, and it beeps!
+
 ### Flashing
 
 The build used for demonstration purposes is available here and can be flashed on a device by:
@@ -60,11 +63,29 @@ ANDROID_HOME environment variable set.
       $ ./flash-all.sh
       ```
 
-The device will reboot when the process is complete and the kiosk app will load.
+The device will reboot when the process is complete and the kiosk app will load. After flashing,
+it's a good idea to set up the Wifi on the device as described in the next section.
+
+### Wifi
+
+There is no UI for setting up the Wifi connection on the device. To connect it to a network plug 
+the device into a USB port and run the following (this only needs to be done once):
+
+```bash
+$ adb connect <address_of_device>
+$ adb shell
+$ am am startservice \
+    -n com.google.wifisetup/.WifiSetupService \
+    -a WifiSetupService.Connect \
+    -e ssid <ssid_of_network> \
+    -e passphrase <password>
+```
+
+More information is [available here](https://developer.android.com/things/hardware/wifi-adb).
 
 ## Notes
 
 The app will remember the kiosk id that it's assigned after it has registered. If you stop the 
 kiosk server this information will be lost and the kiosk app will show an error unless you 
-re-register a new kiosk with the same id. You can "reset" the app by uninstalling and reinstalling 
-the app, and we might add a button for it in the future!
+re-register a new kiosk with the same id. You can "reset" the app by pressing the "Reset Kiosk"
+button from the overflow menu at the top right hand corner of the screen.

--- a/app/kiosk-client/build.gradle
+++ b/app/kiosk-client/build.gradle
@@ -43,8 +43,19 @@ android {
         enabled = true
     }
     sourceSets {
-        main.proto.srcDirs += "${projectDir}/../../protos"
+        main {
+            proto {
+                srcDir "${projectDir}/../../protos"
+                exclude "api-common-protos"
+            }
+        }
         test.java.srcDirs += "${project.buildDir}/generated/source/protoTest/debugUnitTest/client"
+    }
+    configurations.all {
+        resolutionStrategy.force "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    }
+    testOptions {
+        unitTests.returnDefaultValues = true
     }
 }
 
@@ -65,11 +76,13 @@ dependencies {
     api "android.arch.lifecycle:extensions:$lifecycle_version"
 
     // temporary
-    api 'com.github.googleapis.gax-kotlin:kgax-grpc:5b047e1'
-    compileOnly 'com.github.googleapis:gapic-generator-kotlin:cbaa366'
+    api 'com.github.googleapis.gax-kotlin:kgax-grpc:ad942b1'
+    compileOnly 'com.github.googleapis:gapic-generator-kotlin:42fdea4'
 
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation 'com.nhaarman:mockito-kotlin:1.6.0'
+    testImplementation "com.google.truth:truth:0.42"
+    testImplementation "android.arch.core:core-testing:$lifecycle_version"
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
@@ -87,7 +100,7 @@ protobuf {
             artifact = 'com.google.protobuf:protoc-gen-javalite:3.0.0'
         }
         client {
-            artifact = 'com.github.googleapis:gapic-generator-kotlin:cbaa366:core@jar'
+            artifact = 'com.github.googleapis:gapic-generator-kotlin:42fdea4:core@jar'
         }
     }
     generateProtoTasks {

--- a/app/kiosk-client/lint.xml
+++ b/app/kiosk-client/lint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="InvalidPackage">
+        <ignore path="*/io.grpc/grpc-core/*"/>
+    </issue>
+</lint>
+

--- a/app/kiosk-client/src/main/java/com/google/example/kiosk/client/MainActivity.kt
+++ b/app/kiosk-client/src/main/java/com/google/example/kiosk/client/MainActivity.kt
@@ -111,9 +111,17 @@ open class MainActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
         // open settings activity on click
-        if (item?.itemId == R.id.action_settings) {
-            startActivity(Intent(this, SettingsActivity::class.java))
-            finish()
+        when (item?.itemId) {
+            R.id.action_settings -> {
+                val intent = Intent(this, SettingsActivity::class.java)
+                intent.putExtra(SettingsActivity.EXTRA_RETURN_TO_ACTIVITY, this::class.java)
+                startActivity(intent)
+                finish()
+            }
+            R.id.action_reset_kiosk -> {
+                Log.i(TAG, "Resetting kiosk...")
+                registerKiosk()
+            }
         }
         return super.onOptionsItemSelected(item)
     }
@@ -175,6 +183,7 @@ open class MainActivity : AppCompatActivity() {
         super.onDestroy()
 
         // shutdown channel
+        Log.d(TAG, "Shutting down client")
         ShutdownTask(displayClient).execute()
     }
 

--- a/app/kiosk-client/src/main/java/com/google/example/kiosk/client/MainThreadExecutor.kt
+++ b/app/kiosk-client/src/main/java/com/google/example/kiosk/client/MainThreadExecutor.kt
@@ -17,18 +17,28 @@
 package com.google.example.kiosk.client
 
 import android.os.Handler
-import java.util.concurrent.Executor
 import android.os.Looper
+import android.support.annotation.VisibleForTesting
 import com.google.kgax.grpc.Callback
 import com.google.kgax.grpc.FutureCall
 import com.google.kgax.grpc.on
+import java.util.concurrent.Executor
 
-/** Executor for the main thread */
+/** Executor for the main thread. */
 object MainThreadExecutor : Executor {
     private val handler = Handler(Looper.getMainLooper())
 
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    var delegate: Executor? = null
+
     override fun execute(command: Runnable) {
-        handler.post(command)
+        delegate.let {
+            if (it != null) {
+                it.execute(command)
+            } else {
+                handler.post(command)
+            }
+        }
     }
 }
 

--- a/app/kiosk-client/src/main/java/com/google/example/kiosk/client/SettingsActivity.kt
+++ b/app/kiosk-client/src/main/java/com/google/example/kiosk/client/SettingsActivity.kt
@@ -30,6 +30,10 @@ import kotlinx.android.synthetic.main.activity_settings.*
  */
 class SettingsActivity : AppCompatActivity() {
 
+    companion object {
+        const val EXTRA_RETURN_TO_ACTIVITY = "return-activity"
+    }
+
     private lateinit var model: KioskSettingsViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -60,7 +64,8 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     private fun goToMainActivity() {
-        startActivity(Intent(this, MainActivity::class.java))
+        val clazz = intent?.extras?.getSerializable(EXTRA_RETURN_TO_ACTIVITY) as? Class<*>
+        startActivity(Intent(this, clazz ?: MainActivity::class.java))
         finish()
     }
 }

--- a/app/kiosk-client/src/main/res/layout/activity_main.xml
+++ b/app/kiosk-client/src/main/res/layout/activity_main.xml
@@ -92,7 +92,7 @@
                 android:id="@+id/signImage"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:scaleType="centerCrop"
+                android:scaleType="@{Vis.scaleType(model.scaleType)}"
                 android:background="@color/colorWhite"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintLeft_toLeftOf="parent"
@@ -141,7 +141,7 @@
 
             <!-- Sign text (when image is present) -->
             <LinearLayout
-                android:visibility="@{Vis.showSign(model.connected, model.errorMessage, model.sign, model.textPosition == TextPosition.BOTTOM)}"
+                android:visibility="@{Vis.showSign(model.connected, model.errorMessage, model.sign, model.textPosition == TextPosition.BOTTOM, true)}"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"

--- a/app/kiosk-client/src/main/res/menu/tool_bar_menu.xml
+++ b/app/kiosk-client/src/main/res/menu/tool_bar_menu.xml
@@ -22,4 +22,9 @@
         android:icon="@drawable/baseline_settings_white_24"
         android:title="@string/settings"
         app:showAsAction="always" />
+    <item
+        android:id="@+id/action_reset_kiosk"
+        android:enabled="true"
+        android:title="@string/reset_kiosk"
+        app:showAsAction="never" />
 </menu>

--- a/app/kiosk-client/src/main/res/values/strings.xml
+++ b/app/kiosk-client/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="error_kiosk_sign_update">Failed to update sign</string>
 
     <string name="settings">Settings</string>
+    <string name="reset_kiosk">Reset Kiosk</string>
 
     <string name="hint_server_hostname">Kiosk Server Hostname</string>
     <string name="hint_port">Port</string>

--- a/app/kiosk-client/src/test/java/com/google/example/kiosk/client/KioskViewModelTest.kt
+++ b/app/kiosk-client/src/test/java/com/google/example/kiosk/client/KioskViewModelTest.kt
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.example.kiosk.client
+
+import android.app.Application
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import android.view.View
+import android.widget.ImageView
+import com.google.common.truth.Truth.assertThat
+import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.SettableFuture
+import com.google.example.kiosk.client.KioskViewModel.Vis
+import com.google.kgax.grpc.CallResult
+import com.google.kgax.grpc.FutureCall
+import com.google.kgax.grpc.ResponseMetadata
+import com.google.kgax.grpc.ResponseStream
+import com.google.kgax.grpc.ServerStreamingCall
+import com.google.type.LatLng
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.check
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import kiosk.DisplayClient
+import kiosk.GetSignIdResponse
+import kiosk.Kiosk
+import kiosk.ScreenSize
+import kiosk.Sign
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.MockitoJUnitRunner
+import java.util.concurrent.Executor
+
+/**
+ * Basic unit tests for the [KioskViewModel].
+ */
+@RunWith(MockitoJUnitRunner::class)
+class KioskViewModelTest {
+
+    @get:Rule
+    var rule: TestRule = object : InstantTaskExecutorRule() {
+        override fun starting(description: Description?) {
+            super.starting(description)
+            MainThreadExecutor.delegate = MoreExecutors.directExecutor()
+        }
+
+        override fun finished(description: Description?) {
+            super.finished(description)
+            MainThreadExecutor.delegate = null
+        }
+    }
+
+    @Mock
+    lateinit var app: Application
+
+    @Mock
+    lateinit var client: DisplayClient
+
+    lateinit var model: KioskViewModel
+
+    @Before
+    fun before() {
+        model = KioskViewModel(app, client)
+        whenever(app.getString(any())).doReturn("a string!")
+    }
+
+    @Test
+    fun canRegisterAKiosk() {
+        val kiosk = Kiosk {}
+        val future = future(kiosk)
+        whenever(client.createKiosk(any())).doReturn(future)
+
+        val location = LatLng {
+            latitude = 4.2
+            longitude = 5.6
+        }
+        val screenSize = ScreenSize {
+            width = 100
+            height = 200
+        }
+
+        var result: Kiosk? = null
+        model.registerKiosk("my kiosk", location, screenSize) { result = it.body }
+
+        assertThat(result).isEqualTo(kiosk)
+        assertThat(model.connected.value).isFalse()
+        assertThat(model.kiosk.value).isNull()
+        assertThat(model.sign.value).isNull()
+        assertThat(model.errorMessage.value).isNull()
+        assertThat(model.errorStacktrace.value).isNull()
+
+        verify(client).createKiosk(check {
+            assertThat(it.name).isEqualTo("my kiosk")
+            assertThat(it.location).isEqualTo(location)
+            assertThat(it.size).isEqualTo(screenSize)
+            assertThat(it.createTime).isNotNull()
+        })
+    }
+
+    @Test
+    fun canFailToRegisterAKiosk() {
+        val future = futureError<Kiosk>(RuntimeException())
+        whenever(client.createKiosk(any())).doReturn(future)
+
+        model.registerKiosk("a kiosk", LatLng {}, ScreenSize {}) {}
+
+        assertThat(model.connected.value).isFalse()
+        assertThat(model.kiosk.value).isNull()
+        assertThat(model.sign.value).isNull()
+        assertThat(model.errorMessage.value).isNotNull()
+        assertThat(model.errorStacktrace.value).isNotNull()
+    }
+
+    @Test
+    fun canSwitchToKiosk() {
+        val kiosk = Kiosk {}
+        val sign = Sign { id = 10 }
+        val future = future(kiosk)
+        whenever(client.getKiosk(any())).doReturn(future)
+
+        val signStream: ServerStreamingCall<GetSignIdResponse> = mock()
+        whenever(client.getSignIdsForKioskId(any())).doReturn(signStream)
+
+        val signFuture = future(sign)
+        whenever(client.getSign(any())).doReturn(signFuture)
+
+        whenever(signStream.start(any())).thenAnswer {
+            val fakeStream = FakeResponseStream<GetSignIdResponse>().apply(
+                    responseStreamFromInvocation(it))
+            fakeStream.onNext(GetSignIdResponse { signId = 10 })
+        }
+
+        model.switchToKiosk(5)
+
+        verify(client).getKiosk(check { assertThat(it.id).isEqualTo(5) })
+        verify(client).getSign(check { assertThat(it.id).isEqualTo(10) })
+
+        assertThat(model.connected.value).isTrue()
+        assertThat(model.kiosk.value).isEqualTo(kiosk)
+        assertThat(model.sign.value).isEqualTo(sign)
+        assertThat(model.errorMessage.value).isNull()
+        assertThat(model.errorStacktrace.value).isNull()
+    }
+
+    @Test
+    fun canFailToSwitchToKiosk() {
+        val future = futureError<Kiosk>(RuntimeException())
+        whenever(client.getKiosk(any())).doReturn(future)
+
+        model.switchToKiosk(15)
+
+        verify(client).getKiosk(check { assertThat(it.id).isEqualTo(15) })
+
+        assertThat(model.connected.value).isFalse()
+        assertThat(model.kiosk.value).isNull()
+        assertThat(model.sign.value).isNull()
+        assertThat(model.errorMessage.value).isNotNull()
+        assertThat(model.errorStacktrace.value).isNotNull()
+    }
+
+    @Test
+    fun canFailToSubscribeToSignChanges() {
+        val kiosk = Kiosk {}
+        val future = future(kiosk)
+        whenever(client.getKiosk(any())).doReturn(future)
+
+        val signStream: ServerStreamingCall<GetSignIdResponse> = mock()
+        whenever(client.getSignIdsForKioskId(any())).doReturn(signStream)
+
+        whenever(signStream.start(any())).thenAnswer {
+            val fakeStream = FakeResponseStream<GetSignIdResponse>().apply(
+                    responseStreamFromInvocation(it))
+            fakeStream.onError(RuntimeException())
+        }
+
+        model.switchToKiosk(55)
+
+        verify(client).getKiosk(check { assertThat(it.id).isEqualTo(55) })
+
+        assertThat(model.connected.value).isFalse()
+        assertThat(model.kiosk.value).isEqualTo(kiosk)
+        assertThat(model.sign.value).isNull()
+        assertThat(model.errorMessage.value).isNotNull()
+        assertThat(model.errorStacktrace.value).isNotNull()
+    }
+
+    @Test
+    fun canFailToFetchSign() {
+        val kiosk = Kiosk {}
+        val future = future(kiosk)
+        whenever(client.getKiosk(any())).doReturn(future)
+
+        val signStream: ServerStreamingCall<GetSignIdResponse> = mock()
+        whenever(client.getSignIdsForKioskId(any())).doReturn(signStream)
+
+        val signFuture = futureError<Sign>(RuntimeException())
+        whenever(client.getSign(any())).doReturn(signFuture)
+
+        whenever(signStream.start(any())).thenAnswer {
+            val fakeStream = FakeResponseStream<GetSignIdResponse>().apply(
+                    responseStreamFromInvocation(it))
+            fakeStream.onNext(GetSignIdResponse { signId = 100 })
+        }
+
+        model.switchToKiosk(50)
+
+        verify(client).getKiosk(check { assertThat(it.id).isEqualTo(50) })
+        verify(client).getSign(check { assertThat(it.id).isEqualTo(100) })
+
+        assertThat(model.connected.value).isFalse()
+        assertThat(model.kiosk.value).isEqualTo(kiosk)
+        assertThat(model.sign.value).isNull()
+        assertThat(model.errorMessage.value).isNotNull()
+        assertThat(model.errorStacktrace.value).isNotNull()
+    }
+
+    @Test
+    fun canToggleScaleType() {
+        val values = mutableListOf<ImageView.ScaleType?>()
+        do {
+            values.add(model.scaleType.value)
+            model.toggleScaleType()
+        } while (values.size < 3)
+        assertThat(values).containsExactly(
+                ImageView.ScaleType.CENTER_CROP,
+                ImageView.ScaleType.CENTER_INSIDE,
+                ImageView.ScaleType.FIT_CENTER
+        )
+    }
+
+    @Test
+    fun visibilityShowProgress() {
+        assertThat(Vis.showProgress(true, "error")).isEqualTo(View.GONE)
+        assertThat(Vis.showProgress(true, null)).isEqualTo(View.GONE)
+        assertThat(Vis.showProgress(false, "error")).isEqualTo(View.GONE)
+        assertThat(Vis.showProgress(false, null)).isEqualTo(View.VISIBLE)
+        assertThat(Vis.showProgress(null, "error")).isEqualTo(View.GONE)
+        assertThat(Vis.showProgress(null, null)).isEqualTo(View.GONE)
+    }
+
+    @Test
+    fun visibilityShowIfError() {
+        assertThat(Vis.showIfError(null)).isEqualTo(View.GONE)
+        assertThat(Vis.showIfError("hello")).isEqualTo(View.VISIBLE)
+    }
+
+    @Test
+    fun visibilityShowSign() {
+        assertThat(Vis.showSign(true, null, Sign {})).isEqualTo(View.VISIBLE)
+        assertThat(Vis.showSign(true, null, null)).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(true, "err", Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(true, "err", null)).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(false, null, Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(false, null, null)).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(false, "err", Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(false, "err", null)).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(true, null, Sign {}, false)).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(true, null, Sign {}, true)).isEqualTo(View.VISIBLE)
+        assertThat(Vis.showSign(false, "err", Sign {}, isText = true)).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(false, "err", Sign { text = "hi" }, isText = true)).isEqualTo(
+                View.GONE)
+        assertThat(Vis.showSign(null, null, Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(null, null, null)).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(null, "err", Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showSign(null, "err", null)).isEqualTo(View.GONE)
+    }
+
+    @Test
+    fun visibilityShowNoSign() {
+        assertThat(Vis.showNoSign(true, null, Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(true, null, null)).isEqualTo(View.VISIBLE)
+        assertThat(Vis.showNoSign(true, "err", Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(true, "err", null)).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(false, null, Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(false, null, null)).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(false, "err", Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(false, "err", null)).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(null, null, Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(null, null, null)).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(null, "err", Sign {})).isEqualTo(View.GONE)
+        assertThat(Vis.showNoSign(null, "err", null)).isEqualTo(View.GONE)
+    }
+
+    @Test
+    fun visibilityScaleType() {
+        assertThat(Vis.scaleType(null)).isEqualTo(ImageView.ScaleType.CENTER_CROP)
+        for (type in ImageView.ScaleType.values()) {
+            assertThat(Vis.scaleType(type)).isEqualTo(type)
+        }
+    }
+
+    private fun <T> future(response: T): FutureCall<T> {
+        val future = SettableFuture.create<CallResult<T>>()
+        future.set(CallResult(response, ResponseMetadata()))
+        return future
+    }
+
+    private fun <T> futureError(cause: Throwable): FutureCall<T> {
+        val future = SettableFuture.create<CallResult<T>>()
+        future.setException(cause)
+        return future
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> responseStreamFromInvocation(invocation: InvocationOnMock) =
+            invocation.arguments.first() as (ResponseStream<T>.() -> kotlin.Unit)
+}
+
+private class FakeResponseStream<T>(
+    override var executor: Executor? = null,
+    override var ignoreCompletedIf: () -> Boolean = { false },
+    override var ignoreErrorIf: (Throwable) -> Boolean = { false },
+    override var ignoreIf: () -> Boolean = { false },
+    override var ignoreNextIf: (T) -> Boolean = { false },
+    override var onCompleted: () -> Unit = {},
+    override var onError: (Throwable) -> Unit = {},
+    override var onNext: (T) -> Unit = {}
+) : ResponseStream<T> {
+    override fun close() {}
+}

--- a/app/kiosk-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/kiosk-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/app/mobile/lint.xml
+++ b/app/mobile/lint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="InvalidPackage">
+        <ignore path="*/io.grpc/grpc-core/*"/>
+    </issue>
+</lint>
+

--- a/app/things/lint.xml
+++ b/app/things/lint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="InvalidPackage">
+        <ignore path="*/io.grpc/grpc-core/*"/>
+    </issue>
+</lint>
+

--- a/app/things/src/main/AndroidManifest.xml
+++ b/app/things/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="com.google.android.things.permission.USE_PERIPHERAL_IO" />
     <uses-permission android:name="com.google.android.things.permission.MANAGE_INPUT_DRIVERS" />
+    <uses-permission android:name="com.google.android.things.permission.MANAGE_UPDATE_POLICY" />
+    <uses-permission android:name="com.google.android.things.permission.PERFORM_UPDATE_NOW" />
 
     <application
         android:allowBackup="true"

--- a/app/things/src/main/java/com/google/example/kiosk/client/MainActivityThings.kt
+++ b/app/things/src/main/java/com/google/example/kiosk/client/MainActivityThings.kt
@@ -35,7 +35,7 @@ class MainActivityThings : MainActivity() {
         super.onCreate(savedInstanceState)
 
         // show the available buttons and active them
-        Sensors.toggleLeds(red = true, green = false, blue = false)
+        Sensors.toggleLeds(red = true, green = false, blue = true)
         Sensors.getButtonDrivers().let { drivers ->
             drivers.a.register()
             drivers.b.register()
@@ -82,10 +82,15 @@ class MainActivityThings : MainActivity() {
 
         // check for the "reset" sequence of button presses
         if (!down && buttons.isResetSequence()) {
-            Log.i(TAG, "Resetting kiosk (reset button sequence)..." + System.currentTimeMillis())
+            Log.i(TAG, "Resetting kiosk (reset button sequence)...")
 
             buttons.clearSequence()
             registerKiosk()
+        }
+
+        // check for scale adjustment
+        if (!down && keyCode == KeyEvent.KEYCODE_A) {
+            model.toggleScaleType()
         }
     }
 
@@ -112,13 +117,13 @@ private class ButtonState {
 
     /**
      * Tests if the last sequence of key events is the "reset" signal
-     * (3 A's in a row within a short time period)
+     * (3 C's in a row within a short time period)
      */
     fun isResetSequence(): Boolean {
         val now = System.currentTimeMillis()
         return sequence
                 .filter { now - it.time < 4_000 }
-                .joinToString("") { it.button } == "aaa"
+                .joinToString("") { it.button } == "ccc"
     }
 
     /** Forgets all previous button presses */

--- a/app/things/src/main/java/com/google/example/kiosk/client/MainActivityThings.kt
+++ b/app/things/src/main/java/com/google/example/kiosk/client/MainActivityThings.kt
@@ -23,6 +23,10 @@ import android.view.KeyEvent
 import kiosk.Kiosk
 import kiosk.Sign
 import kotlin.properties.Delegates
+import com.google.android.things.update.UpdatePolicy
+import com.google.android.things.update.UpdateManager
+import java.util.concurrent.TimeUnit
+
 
 private const val TAG = "Main"
 
@@ -33,6 +37,12 @@ class MainActivityThings : MainActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val manager = UpdateManager.getInstance()
+        manager.setPolicy(UpdatePolicy.Builder()
+                .setPolicy(UpdatePolicy.POLICY_APPLY_AND_REBOOT)
+                .setApplyDeadline(1L, TimeUnit.DAYS)
+                .build())
 
         // show the available buttons and active them
         Sensors.toggleLeds(red = true, green = false, blue = true)


### PR DESCRIPTION
Fixed a few issues related to resets, bumped the generator version so that streaming calls could be cancelled when the kiosk is reset, and added a "reset" button in an obscure location so it's there if needed.

I had planned to add a Wifi button, but it turns out AT doesn't include the settings UI so I updated the readme with the instructions for setting up Wifi instead.

Also added some tests and a button handler for toggling how the images are scaled.