### PR TITLE
Moves Kiosk proto with HTTP annotations to endpoints/ directory.

### DIFF
--- a/COMPILE-PROTOS.sh
+++ b/COMPILE-PROTOS.sh
@@ -33,9 +33,9 @@ protoc protos/kiosk.proto \
   --descriptor_set_out=generated/kiosk_descriptor.pb \
   --go_out=plugins=grpc:generated
 
-protoc protos/kiosk_with_http.proto \
+protoc endpoints/kiosk_with_http.proto \
   -I protos/api-common-protos \
-  -I protos \
+  -I endpoints \
   --include_imports \
   --include_source_info \
   --descriptor_set_out=generated/kiosk_with_http_descriptor.pb

--- a/endpoints/kiosk_with_http.proto
+++ b/endpoints/kiosk_with_http.proto
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Note: this file differs from protos/kiosk.proto primarily in HTTP
+// annotations for methods that can be transcoded as HTTP/1.1.
+
 syntax = "proto3";
 
 import "google/api/annotations.proto";
@@ -81,27 +84,27 @@ service Display {
 
 // Describes a hardware device that can display signs.
 message Kiosk {
-  int32 id = 1;                   // unique id
-  string name = 2;      // name of device hardware
-  ScreenSize size = 3;      // screen size
-  google.type.LatLng location = 4;  // kiosk location
+  int32 id = 1;                       // unique id
+  string name = 2;                    // name of device hardware
+  ScreenSize size = 3;                // screen size
+  google.type.LatLng location = 4;    // kiosk location
   google.protobuf.Timestamp create_time = 5;
 }
 
 // Describes a digital sign.
 // Signs can include text, images, or both.
 message Sign {
-  int32 id = 1;           // unique id
-  string name = 2;      // name of sign
-  string text = 3;        // text to display
-  bytes image = 4;        // image to display
+  int32 id = 1;                       // unique id
+  string name = 2;                    // name of sign
+  string text = 3;                    // text to display
+  bytes image = 4;                    // image to display
   google.protobuf.Timestamp create_time = 5;
 }
 
 // Represents the size of a screen in pixels.
 message ScreenSize {
-  int32 width = 1;      // screen width
-  int32 height = 2;     // screen height
+  int32 width = 1;                    // screen width
+  int32 height = 2;                   // screen height
 }
 
 

--- a/protos/kiosk.proto
+++ b/protos/kiosk.proto
@@ -60,27 +60,27 @@ service Display {
 
 // Describes a hardware device that can display signs.
 message Kiosk {
-  int32 id = 1;               		// unique id
-  string name = 2;			// name of device hardware
-  ScreenSize size = 3;			// screen size
-  google.type.LatLng location = 4;	// kiosk location
+  int32 id = 1;                       // unique id
+  string name = 2;                    // name of device hardware
+  ScreenSize size = 3;                // screen size
+  google.type.LatLng location = 4;    // kiosk location
   google.protobuf.Timestamp create_time = 5;
 }
 
 // Describes a digital sign.
 // Signs can include text, images, or both.
 message Sign {
-  int32 id = 1;     			// unique id
-  string name = 2;			// name of sign
-  string text = 3;   			// text to display
-  bytes image = 4;   			// image to display
+  int32 id = 1;                       // unique id
+  string name = 2;                    // name of sign
+  string text = 3;                    // text to display
+  bytes image = 4;                    // image to display
   google.protobuf.Timestamp create_time = 5;
 }
 
 // Represents the size of a screen in pixels.
 message ScreenSize {
-  int32 width = 1;			// screen width
-  int32 height = 2;			// screen height
+  int32 width = 1;                    // screen width
+  int32 height = 2;                   // screen height
 }
 
 


### PR DESCRIPTION
This keeps the protos/ directory clearer for other build paths in this repo.