### PR TITLE
update protobuf-gradle-plugin@0.8.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,9 +23,10 @@ buildscript {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/app/gradle/wrapper/gradle-wrapper.properties
+++ b/app/gradle/wrapper/gradle-wrapper.properties
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-#Fri Aug 17 17:42:55 PDT 2018
+#Tue Sep 25 15:36:12 CDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/app/kiosk-client/build.gradle
+++ b/app/kiosk-client/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id "com.google.protobuf" version "0.8.5"
+    id "com.google.protobuf" version "0.8.6"
 }
 
 apply plugin: 'com.android.library'


### PR DESCRIPTION
@timburks found another issue so I figured I'd submit a PR :)

Not my default machine so in order to run the client app I grabbed the latest Android Studio which apparently *had* a known issue with earlier versions of the `protobuf-gradle-plugin` as described [here](https://androidstudio.googleblog.com/2018/06/android-studio-32-beta-1-available.html) As per https://issuetracker.google.com/issues/110564407 there is a now a dependency to use version 0.8.6 which requires and update to `gradle` as well

I was then able to build and run the android app on both emu and device 👍 

