### PR TITLE
refactor k to use gapic

### DIFF
--- a/COMPILE-PROTOS.sh
+++ b/COMPILE-PROTOS.sh
@@ -23,9 +23,12 @@ fi
 go get github.com/golang/protobuf/protoc-gen-go
 go get google.golang.org/grpc
 
-d=$(pwd)
 go get github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
-cd $GOPATH/src/github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic; git checkout v0.1.0; go install; cd $d 
+pushd $(pwd)
+cd $GOPATH/src/github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
+git checkout v0.1.0
+go install
+popd
 
 mkdir -p generated
 

--- a/COMPILE-PROTOS.sh
+++ b/COMPILE-PROTOS.sh
@@ -20,9 +20,12 @@ if [ ! -d "protos/api-common-protos" ]; then
   mv api-common-protos-input-contract protos/api-common-protos
 fi
 
-go get github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
 go get github.com/golang/protobuf/protoc-gen-go
 go get google.golang.org/grpc
+
+d=$(pwd)
+go get github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
+cd $GOPATH/src/github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic; git checkout v0.1.0; go install; cd $d 
 
 mkdir -p generated
 

--- a/COMPILE-PROTOS.sh
+++ b/COMPILE-PROTOS.sh
@@ -14,24 +14,27 @@
 # limitations under the License.
 
 if [ ! -d "protos/api-common-protos" ]; then
-  curl -L -O https://github.com/googleapis/api-common-protos/archive/master.zip
-  unzip master.zip
-  rm -f master.zip
-  mv api-common-protos-master protos/api-common-protos
+  curl -L -O https://github.com/googleapis/api-common-protos/archive/input-contract.zip
+  unzip input-contract.zip
+  rm -f input-contract.zip
+  mv api-common-protos-input-contract protos/api-common-protos
 fi
 
+go get github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
 go get github.com/golang/protobuf/protoc-gen-go
 go get google.golang.org/grpc
 
 mkdir -p generated
 
 protoc protos/kiosk.proto \
+  --go_gapic_out $GOPATH/src/ \
+  --go_gapic_opt 'github.com/googleapis/kiosk/kioskgapic;kioskgapic'  \
   -I protos/api-common-protos \
   -I protos \
   --include_imports \
   --include_source_info \
   --descriptor_set_out=generated/kiosk_descriptor.pb \
-  --go_out=plugins=grpc:generated
+  --go_out=plugins=grpc:$GOPATH/src
 
 protoc endpoints/kiosk_with_http.proto \
   -I protos/api-common-protos \
@@ -39,3 +42,10 @@ protoc endpoints/kiosk_with_http.proto \
   --include_imports \
   --include_source_info \
   --descriptor_set_out=generated/kiosk_with_http_descriptor.pb
+
+# TODO(ndietz) remove this section when pongad fixes w/cloud-go team
+# remove generated code specific to Google gapics in order to compile kioskgapic lib
+sed -i '/	"cloud.google.com\/go\/internal\/version"/d' ./kioskgapic/display_client.go
+sed -i '/	kv := append(\[]string{"gl-go", version.Go()}, keyval...)/d' ./kioskgapic/display_client.go
+sed -i '/	kv = append(kv, "gapic", version.Repo, "gax", gax.Version, "grpc", grpc.Version)/d' ./kioskgapic/display_client.go
+sed -i '/	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))/d' ./kioskgapic/display_client.go

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,11 @@
 all:
 	./COMPILE-PROTOS.sh
 	cd server; go install .
+	cd kioskgapic; go install .
 	cd k; go install .
 
 clean:
 	rm -rf protos/api-common-protos
 	rm -rf generated
+	rm -rf kioskgapic
 

--- a/protos/kiosk.proto
+++ b/protos/kiosk.proto
@@ -17,12 +17,21 @@ syntax = "proto3";
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "google/type/latlng.proto";
+import "google/api/annotations.proto";
 
-option java_multiple_files = true; 
+option java_multiple_files = true;
+option go_package = "github.com/googleapis/kiosk/generated;kiosk"; 
+option (google.api.metadata) = {
+
+  product_name: "Kiosk"
+ 
+  product_uri: "https://github.com/googleapis/kiosk"
+ };
 
 package kiosk;
 
 service Display {
+  option (google.api.default_host) = "localhost";
 
   // Create a kiosk. This enrolls the kiosk for sign display.
   rpc CreateKiosk(Kiosk) returns (Kiosk) {}


### PR DESCRIPTION
Introduces the use of the Go gapic generator plugin and consumption of the gapic by the `k` tool.

There is some generated code specific to Cloud gapics that needs to be removed in order to compile the `kioskgapic` library. The deletion is done via `sed`, which looks messy, but works for automating the install. pongad is aware of the Cloud-specific code and has a plan to fix it with Cloud Go team. Thus, this fix is just some "duct tape" for now.